### PR TITLE
Return to Random.Pcg

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -13,9 +13,9 @@
         "Fuzz"
     ],
     "dependencies": {
-        "elm-community/random-extra": "1.0.0 <= v < 2.0.0",
         "elm-community/shrink": "1.1.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "mgold/elm-random-pcg": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -26,8 +26,7 @@ import Array exposing (Array)
 import Char
 import Util exposing (..)
 import Shrink exposing (Shrinker)
-import Random exposing (Generator)
-import Random.Extra as Random
+import Random.Pcg as Random exposing (Generator)
 import Fuzz.Internal as Internal
 
 

--- a/src/Fuzz/Internal.elm
+++ b/src/Fuzz/Internal.elm
@@ -1,7 +1,7 @@
 module Fuzz.Internal exposing (Fuzzer(Fuzzer))
 
 import Shrink exposing (Shrinker)
-import Random exposing (Generator)
+import Random.Pcg exposing (Generator)
 
 
 type Fuzzer a

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -1,6 +1,6 @@
 module Test.Internal exposing (Test(..), fuzzTest, filter)
 
-import Random exposing (Generator)
+import Random.Pcg as Random exposing (Generator)
 import Test.Expectation exposing (Expectation(..))
 import Dict exposing (Dict)
 import Shrink exposing (Shrinker)

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -17,9 +17,8 @@ module Test.Runner exposing (Runnable, Runner(..), run, fromTest, formatLabels)
 
 import Test exposing (Test)
 import Test.Internal as Internal
-import Util exposing (independentSeed)
 import Expect exposing (Expectation)
-import Random
+import Random.Pcg as Random
 import String
 
 
@@ -84,7 +83,7 @@ distributeSeeds runs test ( startingSeed, runners ) =
         Internal.Test run ->
             let
                 ( seed, nextSeed ) =
-                    Random.step independentSeed startingSeed
+                    Random.step Random.independentSeed startingSeed
             in
                 ( nextSeed, runners ++ [ Runnable (Thunk (\() -> run seed runs)) ] )
 

--- a/src/Util.elm
+++ b/src/Util.elm
@@ -3,7 +3,7 @@ module Util exposing (..)
 {-| This is where I'm sticking Random helper functions I don't want to add to Pcg.
 -}
 
-import Random exposing (..)
+import Random.Pcg exposing (..)
 import Array exposing (Array)
 import String
 
@@ -27,11 +27,3 @@ rangeLengthString minLength maxLength charGenerator =
     in
         (int minLength maxLength)
             `andThen` (\len -> string len charGenerator)
-
-
-{-| An embarrassingly poor stand-in for https://github.com/mgold/elm-random-pcg/blob/2.1.1/src/Random/Pcg.elm#L342-L389
--}
-independentSeed : Generator Seed
-independentSeed =
-    Random.int Random.minInt Random.maxInt
-        |> Random.map Random.initialSeed


### PR DESCRIPTION
Uses Random.Pcg 3.x instead of core. Faster and better statistical qualities, especially for independent seeds.

I've checked that the code compiles but haven't gone further than that. Honestly if this breaks something it will be pretty damning for PCG, either compatibility or statistical quality. But I don't expect that.

🎉 🎉 🎉 
